### PR TITLE
Check if actor is already created

### DIFF
--- a/PixelBot.Orchestrator/Actors/ChannelManagerActor.cs
+++ b/PixelBot.Orchestrator/Actors/ChannelManagerActor.cs
@@ -34,6 +34,11 @@ namespace PixelBot.Orchestrator.Actors
 
 		private void GetChannelActor(JoinChannel msg) {
 
+			if (_ChannelActors.ContainsKey(msg.ChannelName)) {
+				Logger.Log(Akka.Event.LogLevel.InfoLevel, $"Actor for channel '{msg.ChannelName}' already present.");
+				return;
+			}
+
 			var config = DataContext.GetConfigurationForChannel(msg.ChannelName);
 			var props = Props.Create<ChannelActor>(config);
 


### PR DESCRIPTION
Hi. 

I am not sure if you welcome this PR, but I'll try.  

I think there si possibility to get `ArgumentException` in case someone will try the same channel multiple times.
